### PR TITLE
Updates to repl script

### DIFF
--- a/repl.sh
+++ b/repl.sh
@@ -1,5 +1,0 @@
-#!/bin/bash -e
-
-./scripts/ninja.js build
-BS_PLAYGROUND=../../frontend/engine_bs node ./scripts/repl.js
-

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -139,5 +139,5 @@ var cmi_files = [
   .map(x => `--file ${x}`)
   .join(` `);
 e(
-  `js_of_ocaml --disable share --toplevel +weak.js ./polyfill.js jsc.byte ${includes} ${cmi_files} -o ${playground}/exports.js`
+  `js_of_ocaml --disable share --toplevel +weak.js ./polyfill.js jsc.byte ${includes} ${cmi_files} -o ${playground}/bs.js`
 );

--- a/scripts/repl.sh
+++ b/scripts/repl.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+./ninja.js build
+BS_PLAYGROUND=../../sketch-sh/client/public ./repl.js


### PR DESCRIPTION
This PR moves `repl.sh` script to `scripts` folder and also renames the exported js file to `bs.js`.

These changes are needed for the instructions updated in bs engine readme (https://github.com/Sketch-sh/sketch-sh/pull/232) to work.